### PR TITLE
Deprecated CeilingTime

### DIFF
--- a/coarsetime/coarsetime.go
+++ b/coarsetime/coarsetime.go
@@ -22,6 +22,9 @@ func init() {
 	}()
 }
 
+// CeilingTime
+//
+// Deprecated: As of Go 1.17, Performance is lower than time.Now().
 func CeilingTime() time.Time {
 	tp := coarseTime.Load().(*time.Time)
 	return (*tp).Add(frequency)

--- a/coarsetime/coarsetime_test.go
+++ b/coarsetime/coarsetime_test.go
@@ -2,6 +2,7 @@ package coarsetime
 
 import (
 	"testing"
+	"time"
 )
 
 func TestFloorTime(t *testing.T) {
@@ -21,5 +22,11 @@ func BenchmarkFloorTime(b *testing.B) {
 func BenchmarkCeilingTime(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		CeilingTime()
+	}
+}
+
+func BenchmarkTime(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		time.Now()
 	}
 }


### PR DESCRIPTION
As of Go 1.17, Performance is lower than time.Now().