### PR TITLE
Fix Security CI

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -2,6 +2,9 @@ name: "Security Scan"
 
 on:
   push:
+    branches:
+      - main
+  pull_request:
   schedule:
     - cron: '0 0 * * 0'
 
@@ -12,7 +15,7 @@ jobs:
       GO111MODULE: on
     steps:
       - name: Checkout Source
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run Gosec Security Scanner
         uses: securego/gosec@master
         with:


### PR DESCRIPTION
FIx Code Scanning CI requires write access, but Dependabot on the "push" event run with read-only access. 

Fixed: #88