### PR TITLE
Upgrade golang-jwt dependency to v5

### DIFF
--- a/jwt/go.mod
+++ b/jwt/go.mod
@@ -3,3 +3,5 @@ module go.x2ox.com/sorbifolia/jwt
 go 1.19
 
 require github.com/golang-jwt/jwt/v4 v4.5.0
+
+require github.com/golang-jwt/jwt/v5 v5.0.0

--- a/jwt/go.sum
+++ b/jwt/go.sum
@@ -1,2 +1,4 @@
 github.com/golang-jwt/jwt/v4 v4.5.0 h1:7cYmW1XlMY7h7ii7UhUyChSgS5wUJEnm9uZVTGqOWzg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v5 v5.0.0 h1:1n1XNM9hk7O9mnQoNBGolZvzebBQ7p93ULHRc28XJUE=
+github.com/golang-jwt/jwt/v5 v5.0.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=

--- a/jwt/helper.go
+++ b/jwt/helper.go
@@ -3,24 +3,7 @@ package jwt
 import (
 	"time"
 
-	"github.com/golang-jwt/jwt/v4"
-)
-
-var (
-	ES256 = jwt.SigningMethodES256
-	ES384 = jwt.SigningMethodES384
-	ES512 = jwt.SigningMethodES512
-	EdDSA = jwt.SigningMethodEdDSA
-	HS256 = jwt.SigningMethodHS256
-	HS384 = jwt.SigningMethodHS384
-	HS512 = jwt.SigningMethodHS512
-	RS256 = jwt.SigningMethodRS256
-	RS384 = jwt.SigningMethodRS384
-	RS512 = jwt.SigningMethodRS512
-	PS256 = jwt.SigningMethodPS256
-	PS384 = jwt.SigningMethodPS384
-	PS512 = jwt.SigningMethodPS512
-	None  = jwt.SigningMethodNone
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func NewClaims[T any](data *T) *Claims[T]                 { return &Claims[T]{Data: data} }

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -3,7 +3,7 @@ package jwt
 import (
 	"errors"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type JWT[T any] struct {

--- a/jwt/jwt_test.go
+++ b/jwt/jwt_test.go
@@ -3,7 +3,7 @@ package jwt
 import (
 	"testing"
 
-	"github.com/golang-jwt/jwt/v4"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type Info struct {
@@ -15,7 +15,7 @@ func TestJWT(t *testing.T) {
 
 	gen := Generator{}
 	rpk, _ := gen.Ed25519()
-	j := New(EdDSA, rpk, rpk.Public(), Claims[Info]{})
+	j := New(jwt.SigningMethodEdDSA, rpk, rpk.Public(), Claims[Info]{})
 
 	ts, err := j.Generate(Claims[Info]{
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -58,7 +58,7 @@ func TestJWT_MustGenerate(t *testing.T) {
 
 	gen := Generator{}
 	rpk, _ := gen.Ed25519()
-	j := New(EdDSA, rpk, rpk.Public(), Claims[TestData]{})
+	j := New(jwt.SigningMethodEdDSA, rpk, rpk.Public(), Claims[TestData]{})
 
 	defer func() { _ = recover() }()
 	j.MustGenerate(Claims[TestData]{
@@ -78,7 +78,7 @@ func TestJWT_Parse(t *testing.T) {
 
 	gen := Generator{}
 	rpk, _ := gen.Ed25519()
-	j := New(EdDSA, rpk, rpk.Public(), Claims[any]{})
+	j := New(jwt.SigningMethodEdDSA, rpk, rpk.Public(), Claims[any]{})
 
 	if _, err := j.Parse("1.2.3"); err == nil {
 		t.Error(err)
@@ -90,7 +90,7 @@ func TestJWT_ParseToken(t *testing.T) {
 
 	gen := Generator{}
 	rpk, _ := gen.Ed25519()
-	j := New(EdDSA, rpk, rpk.Public(), Claims[any]{})
+	j := New(jwt.SigningMethodEdDSA, rpk, rpk.Public(), Claims[any]{})
 
 	if _, err := j.ParseToken(nil); err == nil {
 		t.Error("failed to parse")


### PR DESCRIPTION
The golang-jwt dependency has been updated from version 4 to version 5. This involved updates to import statements and adjustments to how signing methods are referenced in our jwt helper functions. Consequently, the go.sum and go.mod files were also updated to reflect this new dependency version.