### PR TITLE
Implement CIDR package with Group, Prefix and Single IP handling

### DIFF
--- a/cidr/cidr.go
+++ b/cidr/cidr.go
@@ -1,0 +1,21 @@
+package cidr
+
+import (
+	"math/big"
+	"net/netip"
+)
+
+type CIDR interface {
+	ContainsIP(netip.Addr) bool
+	NextIP(netip.Addr) netip.Addr
+	Length() *big.Int
+
+	Contains(CIDR) bool
+}
+
+type Consecutive interface {
+	CIDR
+
+	FirstIP() netip.Addr
+	LastIP() netip.Addr
+}

--- a/cidr/exclude.go
+++ b/cidr/exclude.go
@@ -1,0 +1,1 @@
+package cidr

--- a/cidr/go.mod
+++ b/cidr/go.mod
@@ -1,0 +1,3 @@
+module go.x2ox.com/sorbifolia/cidr
+
+go 1.21

--- a/cidr/group.go
+++ b/cidr/group.go
@@ -1,0 +1,54 @@
+package cidr
+
+import (
+	"math/big"
+	"net/netip"
+)
+
+type Group struct {
+	arr []Consecutive
+}
+
+func (x Group) ContainsIP(ip netip.Addr) bool {
+	for i := range x.arr {
+		if x.arr[i].ContainsIP(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+func (x Group) Length() *big.Int {
+	bi := big.NewInt(0)
+	for i := range x.arr {
+		bi.Add(bi, x.arr[i].Length())
+	}
+	return bi
+}
+
+func (x Group) NextIP(ip netip.Addr) netip.Addr {
+	if len(x.arr) == 0 {
+		return netip.Addr{}
+	}
+
+	if !ip.IsValid() {
+		return x.arr[0].FirstIP()
+	}
+
+	for i := range x.arr {
+		if !x.arr[i].ContainsIP(ip) {
+			continue
+		}
+		if addr := x.arr[i].NextIP(ip); addr.IsValid() {
+			return addr
+		}
+		if len(x.arr)-1 != i { // traversal not finished
+			return x.arr[i+1].FirstIP()
+		}
+	}
+
+	if x.arr[0].FirstIP().Is4() {
+		return netip.IPv4Unspecified()
+	}
+	return netip.IPv6Unspecified()
+}

--- a/cidr/ip_prefix.go
+++ b/cidr/ip_prefix.go
@@ -1,0 +1,47 @@
+package cidr
+
+import (
+	"math/big"
+	"net/netip"
+)
+
+type Prefix struct {
+	p netip.Prefix
+}
+
+func (x Prefix) ContainsIP(ip netip.Addr) bool { return x.p.Contains(ip) }
+
+func (x Prefix) Length() *big.Int {
+	return big.NewInt(0).Lsh(big.NewInt(1), uint(x.p.Addr().BitLen()-x.p.Bits()))
+}
+
+func (x Prefix) FirstIP() netip.Addr { return x.p.Addr() }
+func (x Prefix) LastIP() netip.Addr {
+	start := big.NewInt(0).SetBytes(x.p.Addr().AsSlice())
+	lastIP := big.NewInt(0).Add(start, x.Length())
+	lastIP = big.NewInt(0).Sub(lastIP, big.NewInt(1))
+
+	addr, _ := netip.AddrFromSlice(lastIP.Bytes())
+	return addr
+}
+
+func (x Prefix) NextIP(ip netip.Addr) netip.Addr {
+	if !ip.IsValid() {
+		return x.p.Addr()
+	}
+	if ip = ip.Next(); x.ContainsIP(ip) {
+		return ip
+	}
+	if x.p.Addr().Is4() {
+		return netip.IPv4Unspecified()
+	}
+	return netip.IPv6Unspecified()
+}
+
+func (x Prefix) Contains(b CIDR) bool {
+	if val, ok := b.(Consecutive); ok {
+		return x.FirstIP().Compare(val.FirstIP()) <= 0 && x.LastIP().Compare(val.LastIP()) >= 0
+	}
+
+	return false
+}

--- a/cidr/ip_prefix_test.go
+++ b/cidr/ip_prefix_test.go
@@ -1,0 +1,42 @@
+package cidr
+
+import (
+	"fmt"
+	"math/big"
+	"net/netip"
+	"testing"
+)
+
+var testPrefixLength = []struct {
+	val    Prefix
+	expect *big.Int
+}{
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{0, 0, 0, 0}), 0)}, big.NewInt(4294967296)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 0, 0, 0}), 1)}, big.NewInt(2147483648)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 0, 0, 0}), 4)}, big.NewInt(268435456)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 0, 0, 0}), 8)}, big.NewInt(16777216)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 0, 0, 0}), 16)}, big.NewInt(65536)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 0, 0, 0}), 24)}, big.NewInt(256)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom4([4]byte{1, 0, 0, 0}), 32)}, big.NewInt(1)},
+
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom16([16]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), 0)}, big.NewInt(0).Exp(big.NewInt(2), big.NewInt(128), nil)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom16([16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), 80)}, big.NewInt(281474976710656)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom16([16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), 96)}, big.NewInt(4294967296)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom16([16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), 112)}, big.NewInt(65536)},
+	{Prefix{p: netip.PrefixFrom(netip.AddrFrom16([16]byte{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}), 128)}, big.NewInt(1)},
+}
+
+func TestPrefix_Length(t *testing.T) {
+	for _, val := range testPrefixLength {
+		b := val.val.Length()
+		if b.Cmp(val.expect) != 0 {
+			t.Errorf("expected value is %s, but got %s for Prefix length", val.expect.String(), b.String())
+		}
+	}
+}
+
+func TestPrefix_FirstIP(t *testing.T) {
+	for _, val := range testPrefixLength {
+		fmt.Println(val.val.FirstIP(), val.val.LastIP())
+	}
+}

--- a/cidr/ip_range.go
+++ b/cidr/ip_range.go
@@ -1,0 +1,44 @@
+package cidr
+
+import (
+	"math/big"
+	"net/netip"
+)
+
+type Range struct {
+	s, e netip.Addr
+}
+
+func (x Range) ContainsIP(ip netip.Addr) bool {
+	return ip.Compare(x.s) >= 0 && ip.Compare(x.e) <= 0
+}
+
+func (x Range) Length() *big.Int {
+	return big.NewInt(0).Sub(
+		big.NewInt(0).SetBytes(x.s.AsSlice()),
+		big.NewInt(0).SetBytes(x.e.AsSlice()),
+	)
+}
+
+func (x Range) NextIP(ip netip.Addr) netip.Addr {
+	if !ip.IsValid() { // 第一次调用
+		return x.s
+	}
+	if ip = ip.Next(); x.ContainsIP(ip) {
+		return ip
+	}
+
+	if x.s.Is4() {
+		return netip.IPv4Unspecified()
+	}
+	return netip.IPv6Unspecified()
+}
+
+func (x Range) FirstIP() netip.Addr { return x.s }
+func (x Range) LastIP() netip.Addr  { return x.e }
+func (x Range) Contains(b CIDR) bool {
+	if val, ok := b.(Consecutive); ok {
+		return x.FirstIP().Compare(val.FirstIP()) <= 0 && x.LastIP().Compare(val.LastIP()) >= 0
+	}
+	return false
+}

--- a/cidr/ip_single.go
+++ b/cidr/ip_single.go
@@ -1,0 +1,35 @@
+package cidr
+
+import (
+	"math/big"
+	"net/netip"
+)
+
+type Single struct {
+	p netip.Addr
+}
+
+func (x Single) ContainsIP(ip netip.Addr) bool { return x.p.Compare(ip) == 0 }
+
+func (x Single) Length() *big.Int { return big.NewInt(1) }
+
+func (x Single) NextIP(ip netip.Addr) netip.Addr {
+	if !ip.IsValid() && x.p.Compare(ip) != 0 {
+		return x.p
+	}
+	if x.p.Is4() {
+		return netip.IPv4Unspecified()
+	}
+	return netip.IPv6Unspecified()
+}
+
+func (x Single) FirstIP() netip.Addr { return x.p }
+func (x Single) LastIP() netip.Addr  { return x.p }
+
+func (x Single) Contains(b CIDR) bool {
+	s, ok := b.(Single)
+	if !ok {
+		return false
+	}
+	return s.p.Compare(x.p) == 0
+}

--- a/go.work
+++ b/go.work
@@ -1,6 +1,7 @@
 go 1.21
 
 use (
+	cidr
 	coarsetime
 	cryptutils
 	datastructures


### PR DESCRIPTION
Added a suite of new files to implement a CIDR package. This package comprises a range of functions and structures for handling IP addresses, including Group, Prefix, Single IP along with their length, test methods, and other utilities.