### PR TITLE
Fix: update calls to `runtime.fastrand` to use `cheaprand` for compatibility with Go 1.22

### DIFF
--- a/random/fast.go
+++ b/random/fast.go
@@ -24,7 +24,7 @@ func (r fastRand) SetRandBytes(data []byte) Random {
 	return &fastRand{r.randString.SetRandBytes(data)}
 }
 
-func (r fastRand) Uint() uint     { return _fastRandUint() }
+func (r fastRand) Uint() uint     { return uint(_fastRand64()) }
 func (r fastRand) Uint64() uint64 { return _fastRand64() }
 func (r fastRand) Uint32() uint32 { return _fastRand() }
 func (r fastRand) Uint16() uint16 { return uint16(_fastRand()) }
@@ -58,12 +58,3 @@ func remainder[T uint | uint64 | uint32 | uint16 | uint8 | int | int64 | int32 |
 	}
 	return r % n
 }
-
-//go:linkname _fastRand runtime.fastrand
-func _fastRand() uint32
-
-//go:linkname _fastRand64 runtime.fastrand64
-func _fastRand64() uint64
-
-//go:linkname _fastRandUint runtime.fastrandu
-func _fastRandUint() uint

--- a/random/math.go
+++ b/random/math.go
@@ -1,7 +1,7 @@
 package random
 
 import (
-	"math/rand"
+	"math/rand/v2"
 )
 
 type mathRand struct{ *randString }

--- a/random/runtime.go
+++ b/random/runtime.go
@@ -1,0 +1,13 @@
+//go:build !go1.22
+
+package random
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname _fastRand runtime.fastrand
+func _fastRand() uint32
+
+//go:linkname _fastRand64 runtime.fastrand64
+func _fastRand64() uint64

--- a/random/runtime_1.22.go
+++ b/random/runtime_1.22.go
@@ -1,0 +1,13 @@
+//go:build go1.22
+
+package random
+
+import (
+	_ "unsafe"
+)
+
+//go:linkname _fastRand runtime.cheaprand
+func _fastRand() uint32
+
+//go:linkname _fastRand64 runtime.cheaprand64
+func _fastRand64() uint64

--- a/random/safe.go
+++ b/random/safe.go
@@ -1,7 +1,7 @@
 package random
 
 import (
-	cr "crypto/rand"
+	"crypto/rand"
 	"unsafe"
 
 	pn "go.x2ox.com/sorbifolia/pyrokinesis"
@@ -16,7 +16,7 @@ func Safe() Random {
 func (r safeRand) RandString(length int) string {
 	arr := make([]byte, length)
 	arr1 := make([]int, length)
-	_, _ = cr.Read(arr)
+	_, _ = rand.Read(arr)
 	for i := range arr {
 		arr1[i] = int(uint64(arr[i]) * uint64(r.randBytesLen) >> 8)
 	}
@@ -53,7 +53,7 @@ func (r safeRand) Int8n(n int8) int8    { return remainder(n, r.Int8()) }
 
 func (r safeRand) read(num int) []byte {
 	arr := make([]byte, num)
-	_, _ = cr.Read(arr)
+	_, _ = rand.Read(arr)
 	return arr
 }
 


### PR DESCRIPTION
Fix: update calls to `runtime.fastrand` to use `cheaprand` for compatibility with Go 1.22

In Golang 1.22, the `runtime.fastrand` method was renamed to `cheaprand`. This commit updates all occurrences of `runtime.fastrand` in the project to use the new `cheaprand` method to maintain compatibility with the latest Golang version and address performance concerns.

Refer: https://gist.github.com/Aoang/3dc06f127f3f54507b7e06b7b6550c28